### PR TITLE
Update create_pat_records.sql

### DIFF
--- a/create_pat_records.sql
+++ b/create_pat_records.sql
@@ -26,7 +26,7 @@ WITH
     '01246000000RNnHAAW' AS record_type_id,
     -- Advising Rubric Fields to Carry Over
     financial_aid_package_c,
-    filing_status__c,
+    filing_status_c,
     repayment_plan_c,
     repayment_policies_c,
     loan_exit_c,
@@ -174,7 +174,7 @@ case when gas_term_to_create IN ('Summer') then false else true end as missing_a
     case when term_to_create = 'Fall' then null
     else financial_aid_package_c end as financial_aid_package_c,
     case when term_to_create = 'Fall' then null
-    else filing_status__c end as filing_status__c,
+    else filing_status_c end as filing_status__c,
 
 
 


### PR DESCRIPTION
I think one of those weird scenarios where the query needs to pull the field with just one underscore but in gconnector it's quicker to map the field if it spits the column out with two underscores.